### PR TITLE
INTERLOK-2658 - Spotbugs

### DIFF
--- a/src/main/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreator.java
+++ b/src/main/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreator.java
@@ -16,27 +16,24 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("elasticsearch-rest-client-creator")
 public class ElasticSearchRestClientCreator implements ElasticSearchClientCreator {
-  
+
   private static final String DEFAULT_SCHEME = "http";
 
   @Override
   public TransportClient createTransportClient(List<String> transportUrls) throws CoreException {
     TransportClient tClient = new TransportClient();
-    
+
     List<HttpHost> hosts = new ArrayList<>();
     for(String transportUrl : transportUrls) {
       hosts.add(new HttpHost(this.getHost(transportUrl), this.getPort(transportUrl), this.getScheme(transportUrl)));
     }
-    
+
     RestClientBuilder restClientBuilder = RestClient.builder(hosts.toArray(new HttpHost[0]));
     RestHighLevelClient client = new RestHighLevelClient(restClientBuilder);
-    
+
     Sniffer sniffer = Sniffer.builder(client.getLowLevelClient()).build();
-    
-    tClient.setRestHighLevelClient(client);
-    tClient.setSniffer(sniffer);
-    
-    return tClient;
+
+    return new TransportClient().withRestHighLevelClient(client).withSniffer(sniffer);
   }
 
   private String getHost(String hostUrl) {
@@ -62,12 +59,12 @@ public class ElasticSearchRestClientCreator implements ElasticSearchClientCreato
     }
     return result;
   }
-  
+
   private String getScheme(String hostUrl) {
     String result = DEFAULT_SCHEME;
     if (hostUrl.contains("://"))
       result = hostUrl.substring(0, hostUrl.indexOf("://"));
-    
+
     return result;
   }
 }

--- a/src/main/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreator.java
+++ b/src/main/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreator.java
@@ -21,7 +21,6 @@ public class ElasticSearchRestClientCreator implements ElasticSearchClientCreato
 
   @Override
   public TransportClient createTransportClient(List<String> transportUrls) throws CoreException {
-    TransportClient tClient = new TransportClient();
 
     List<HttpHost> hosts = new ArrayList<>();
     for(String transportUrl : transportUrls) {
@@ -53,8 +52,7 @@ public class ElasticSearchRestClientCreator implements ElasticSearchClientCreato
       result = new URLName(hostUrl).getPort();
     }
     else {
-      String s = hostUrl.substring(hostUrl.lastIndexOf(":") + 1);
-      s.replaceAll("/", "");
+      String s = hostUrl.substring(hostUrl.lastIndexOf(":") + 1).replaceAll("/", "");
       result = Integer.parseInt(s);
     }
     return result;

--- a/src/main/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreator.java
+++ b/src/main/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreator.java
@@ -17,6 +17,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("elasticsearch-rest-client-creator")
 public class ElasticSearchRestClientCreator implements ElasticSearchClientCreator {
 
+  private static final String URI_AUTH_SEPARATOR = "://";
   private static final String DEFAULT_SCHEME = "http";
 
   @Override
@@ -37,7 +38,7 @@ public class ElasticSearchRestClientCreator implements ElasticSearchClientCreato
 
   private String getHost(String hostUrl) {
     String result = hostUrl;
-    if (hostUrl.contains("://")) {
+    if (hostUrl.contains(URI_AUTH_SEPARATOR)) {
       result = new URLName(hostUrl).getHost();
     }
     else {
@@ -48,7 +49,7 @@ public class ElasticSearchRestClientCreator implements ElasticSearchClientCreato
 
   private Integer getPort(String hostUrl) {
     Integer result = 0;
-    if (hostUrl.contains("://")) {
+    if (hostUrl.contains(URI_AUTH_SEPARATOR)) {
       result = new URLName(hostUrl).getPort();
     }
     else {
@@ -60,8 +61,8 @@ public class ElasticSearchRestClientCreator implements ElasticSearchClientCreato
 
   private String getScheme(String hostUrl) {
     String result = DEFAULT_SCHEME;
-    if (hostUrl.contains("://"))
-      result = hostUrl.substring(0, hostUrl.indexOf("://"));
+    if (hostUrl.contains(URI_AUTH_SEPARATOR))
+      result = hostUrl.substring(0, hostUrl.indexOf(URI_AUTH_SEPARATOR));
 
     return result;
   }

--- a/src/main/java/com/adaptris/core/elastic/rest/TransportClient.java
+++ b/src/main/java/com/adaptris/core/elastic/rest/TransportClient.java
@@ -14,9 +14,9 @@ import org.elasticsearch.client.sniff.Sniffer;
 
 public class TransportClient implements Closeable {
 
-  private RestHighLevelClient restHighLevelClient;
+  private transient RestHighLevelClient restHighLevelClient;
 
-  private Sniffer sniffer;
+  private transient Sniffer sniffer;
 
   @Override
   @SuppressWarnings("deprecation")
@@ -29,16 +29,26 @@ public class TransportClient implements Closeable {
     return restHighLevelClient;
   }
 
-  public void setRestHighLevelClient(RestHighLevelClient restHighLevelClient) {
+  private void setRestHighLevelClient(RestHighLevelClient restHighLevelClient) {
     this.restHighLevelClient = restHighLevelClient;
+  }
+
+  public TransportClient withRestHighLevelClient(RestHighLevelClient c) {
+    setRestHighLevelClient(c);
+    return this;
   }
 
   public Sniffer getSniffer() {
     return sniffer;
   }
 
-  public void setSniffer(Sniffer sniffer) {
+  private void setSniffer(Sniffer sniffer) {
     this.sniffer = sniffer;
+  }
+
+  public TransportClient withSniffer(Sniffer c) {
+    setSniffer(c);
+    return this;
   }
 
   public IndexResponse index(IndexRequest request) throws IOException {

--- a/src/main/java/com/adaptris/core/elastic/rest/TransportClient.java
+++ b/src/main/java/com/adaptris/core/elastic/rest/TransportClient.java
@@ -3,10 +3,12 @@ package com.adaptris.core.elastic.rest;
 import java.io.Closeable;
 import java.io.IOException;
 
+import org.apache.commons.io.IOUtils;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.sniff.Sniffer;
 
@@ -17,18 +19,10 @@ public class TransportClient implements Closeable {
   private Sniffer sniffer;
 
   @Override
+  @SuppressWarnings("deprecation")
   public void close() {
-    try {
-      if (this.getSniffer() != null)
-        this.getSniffer().close();
-    }
-    catch (Exception e) { ; }
-
-    try {
-      if (this.getRestHighLevelClient() != null)
-        this.getRestHighLevelClient().close();
-    }
-    catch (Exception e) { ; }
+    IOUtils.closeQuietly(getSniffer());
+    IOUtils.closeQuietly(getRestHighLevelClient());
   }
 
   public RestHighLevelClient getRestHighLevelClient() {
@@ -48,11 +42,11 @@ public class TransportClient implements Closeable {
   }
 
   public IndexResponse index(IndexRequest request) throws IOException {
-    return this.getRestHighLevelClient().index(request);
+    return this.getRestHighLevelClient().index(request, RequestOptions.DEFAULT);
   }
 
   public BulkResponse bulk(BulkRequest bulkRequest) throws IOException {
-    return this.getRestHighLevelClient().bulk(bulkRequest);
+    return this.getRestHighLevelClient().bulk(bulkRequest, RequestOptions.DEFAULT);
   }
 
 }

--- a/src/main/java/com/adaptris/core/elastic/rest/TransportClient.java
+++ b/src/main/java/com/adaptris/core/elastic/rest/TransportClient.java
@@ -1,5 +1,6 @@
 package com.adaptris.core.elastic.rest;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -9,26 +10,11 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.sniff.Sniffer;
 
-import com.adaptris.core.ComponentLifecycle;
-import com.adaptris.core.CoreException;
-
-public class TransportClient implements ComponentLifecycle {
+public class TransportClient implements Closeable {
 
   private RestHighLevelClient restHighLevelClient;
-  
+
   private Sniffer sniffer;
-
-  @Override
-  public void init() throws CoreException {
-  }
-
-  @Override
-  public void start() throws CoreException {
-  }
-
-  @Override
-  public void stop() {
-  }
 
   @Override
   public void close() {
@@ -37,7 +23,7 @@ public class TransportClient implements ComponentLifecycle {
         this.getSniffer().close();
     }
     catch (Exception e) { ; }
-    
+
     try {
       if (this.getRestHighLevelClient() != null)
         this.getRestHighLevelClient().close();
@@ -68,5 +54,5 @@ public class TransportClient implements ComponentLifecycle {
   public BulkResponse bulk(BulkRequest bulkRequest) throws IOException {
     return this.getRestHighLevelClient().bulk(bulkRequest);
   }
-  
+
 }

--- a/src/test/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreatorTest.java
+++ b/src/test/java/com/adaptris/core/elastic/rest/ElasticSearchRestClientCreatorTest.java
@@ -1,0 +1,23 @@
+package com.adaptris.core.elastic.rest;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class ElasticSearchRestClientCreatorTest {
+
+  @Test
+  public void testCreate() throws Exception {
+    ElasticSearchRestClientCreator creator = new ElasticSearchRestClientCreator();
+    TransportClient client = creator.createTransportClient(getTransportUrls());
+    assertNotNull(client);
+    client.close();
+  }
+
+  private List<String> getTransportUrls() {
+    return Arrays.asList("http://localhost:9200", "localhost:9201", "https://localhost:9202");
+  }
+}


### PR DESCRIPTION
Added test for ElasticSearchRestClientCreator.
Changed TransportClient so it only implements Closeable, rather than ComponentLifecycle. ComponentLifecycle was never actually called; and the methods didn't do anything anyway.

Fix RV_RETURN_VALUE_IGNORED and DE_MIGHT_IGNORE from spotbugs.